### PR TITLE
Separate scheduling for minor and major updates

### DIFF
--- a/common.json5
+++ b/common.json5
@@ -1,6 +1,11 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: ["config:best-practices", ":pinAllExceptPeerDependencies"],
+  extends: [
+    "config:best-practices",
+    ":pinAllExceptPeerDependencies",
+    "github>nikobockerman/renovate-config:major-updates.json5",
+    "github>nikobockerman/renovate-config:minor-updates.json5",
+  ],
   lockFileMaintenance: {
     enabled: true,
   },

--- a/major-updates.json5
+++ b/major-updates.json5
@@ -1,0 +1,11 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  packageRules: [
+    {
+      description: "Major updates: min age and schedule",
+      matchUpdateTypes: ["major"],
+      minimumReleaseAge: "2 weeks",
+      schedule: ["* * * * 0,5-6"], // Friday - Sunday
+    },
+  ],
+}

--- a/minor-updates.json5
+++ b/minor-updates.json5
@@ -1,0 +1,11 @@
+{
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  packageRules: [
+    {
+      description: "Minor updates: min age and schedule",
+      matchUpdateTypes: ["minor"],
+      minimumReleaseAge: "5 days",
+      schedule: ["* * * * 0,5-6"], // Friday - Sunday
+    },
+  ],
+}


### PR DESCRIPTION
Increase minimum release age to reduce risk that new minor and major versions have serious bugs. Schedule such updates around weekends.