### PR TITLE
ci: Wait for all checks to pass

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,0 +1,14 @@
+name: Check - All checks pass
+on:
+  pull_request:
+
+jobs:
+  enforce-all-checks:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+    steps:
+      - name: GitHub Checks
+        uses: poseidon/wait-for-status-checks@v0.6.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This job should be possible to mark as required check for branch protections rules and thus should be usable as an enforced check that PRs are mergeable.