### PR TITLE
ci: Use latest renovate for config validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "check:github-actions": "git ls-files '.github/**.yaml' | xargs -t -I {} action-validator {}",
     "check:yarn:dedupe": "yarn dedupe --check",
     "check:prettier": "prettier --check .",
-    "check:renovateconfig": "npx --package=renovate --yes -- renovate-config-validator --strict *.json5 default.json .github/renovate.json5",
+    "check:renovateconfig": "npx --package=renovate@latest --yes --prefer-online renovate-config-validator --strict *.json5 default.json .github/renovate.json5",
     "fix:prettier": "prettier --write --cache-location .prettiercache ."
   },
   "private": true,


### PR DESCRIPTION
Previously the npx command used wasn't explicitly setting the version of renovate package used to be latest stable version. Instead npx picked 37.440.7 locally and in CI also some older version. Why that version got picked up isn't known, but setting explicitly to latest tag fixes the problem.